### PR TITLE
Bugfix: Don't jump to the end of the line when using autocompletion in task edit

### DIFF
--- a/qtodotxt/ui/controls/autocomplete_lineedit.py
+++ b/qtodotxt/ui/controls/autocomplete_lineedit.py
@@ -32,7 +32,10 @@ class AutoCompleteEdit(QtGui.QLineEdit):
             completion = self.replaceAutocompleteKeys(completion)
 
         newtext = currentText[:textFirstPart] + completion + " " + currentText[textLastPart:]
+        newCursorPos = self.cursorPosition() + (len(completion) - completionPrefixSize) + 1
+        
         self.setText(newtext)
+        self.setCursorPosition(newCursorPos)
 
     def replaceAutocompleteKeys(self, completion):
         if completion in self._autocomplete_pairs.keys():


### PR DESCRIPTION
This is a single commit from https://github.com/mNantern/QTodoTxt/pull/113 which can be used independent and removes an annoying bug.