### PR TITLE
Fixed text search filter under Python 3.5

### DIFF
--- a/qtodotxt/lib/filters.py
+++ b/qtodotxt/lib/filters.py
@@ -348,7 +348,7 @@ class SimpleTextFilter(BaseFilter):
         restring = comp.sub(r'^(?=.*\1)', self.text, re.U)
         try:
             if ')' in restring:
-                raise re.error  # otherwise adding closing parenth avoids error here
+                raise re.error('')  # otherwise adding closing parenth avoids error here
             mymatch = re.search(restring, task.text, re.I | re.U)
         except re.error:
             comp2 = re.compile(r'\s*\((?=[^?])', re.U)


### PR DESCRIPTION
Attempt to create re.error without arguments works in Python 3.4 but
apparently fails in 3.5, breaking text search filter functionality.
Fixed by adding an empty msg argument.

fixes #154